### PR TITLE
Automate Docker Mysql

### DIFF
--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -15,4 +15,4 @@ RUN npm install
 # Bundle app source
 COPY . .
 
-CMD [ "npm", "run","dev" ]
+CMD sleep 20s; npm run dev

--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -15,4 +15,4 @@ RUN npm install
 # Bundle app source
 COPY . .
 
-CMD sleep 20s; npm run dev
+CMD sleep 9s; npm run dev

--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -15,4 +15,4 @@ RUN npm install
 # Bundle app source
 COPY . .
 
-CMD sleep 9s; npm run dev
+CMD sleep 9s; npm run pm2:start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
         context: ./schemas
         #dockerfile: Database.Dockerfile
     ports:
-      - "3007:${DB_PORT}"
+      - "${DB_PORT}:${DB_PORT}"
     environment:
       MYSQL_USER: 'hfh'
       MYSQL_PASSWORD: '${DB_PASSWORD}'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,13 @@ services:
         context: ./schemas
         #dockerfile: Database.Dockerfile
     ports:
-      - "${DB_PORT}:${DB_PORT}"
+      - "3007:${DB_PORT}"
     environment:
       MYSQL_USER: 'hfh'
       MYSQL_PASSWORD: '${DB_PASSWORD}'
       MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
       MYSQL_DATABASE: '${DB_NAME}'
+      MYSQL_ROOT_HOST: '%'
 
 
     volumes:
@@ -43,7 +44,12 @@ services:
       - /usr/src/app/node_modules
     environment:
       REDIS_HOST: redis
-      DB_HOST: db
+      DB_HOST: db 
+      DB_USER: 'hfh'
+      DB_PASSWORD: '${DB_PASSWORD}'
+      DB_ROOT_PASSWORD: '${DB_PASSWORD}'
+      DB_NAME: '${DB_NAME}'
+      MYSQL_ROOT_HOST: '%'
     env_file:
       - .env
 

--- a/schemas/Dockerfile
+++ b/schemas/Dockerfile
@@ -1,4 +1,10 @@
 FROM mysql:8
+COPY . .
+#ADD . ./docker-entrypoint-initdb.d/
+ADD . ./bin/docker-entrypoint.sh 
+RUN chmod 0644  ./mysql.sh
 
 ADD . .
+RUN chmod +x  ./mysql.sh
 
+CMD ./mysql.sh 

--- a/schemas/admin_client_schema.sql
+++ b/schemas/admin_client_schema.sql
@@ -1,10 +1,8 @@
-CREATE SCHEMA IF NOT EXISTS homes_for_heroes;
 
 USE homes_for_heroes;
 
 SET FOREIGN_KEY_CHECKS=0;
 
-DROP TABLE IF EXISTS client_users;
 CREATE TABLE IF NOT EXISTS client_users (
     user_id INT NOT NULL AUTO_INCREMENT,
     name VARCHAR(255) NOT NULL,
@@ -26,7 +24,6 @@ CREATE TABLE IF NOT EXISTS client_users (
         REFERENCES chapters(chapter_id)
 );
 
-DROP TABLE IF EXISTS federated_credentials;
 CREATE TABLE IF NOT EXISTS federated_credentials (
     user_id INT NOT NULL UNIQUE,
     provider VARCHAR(255) NOT NULL,
@@ -38,7 +35,6 @@ CREATE TABLE IF NOT EXISTS federated_credentials (
         ON DELETE CASCADE
 );
 
-DROP TABLE IF EXISTS cases;
 CREATE TABLE IF NOT EXISTS cases (
     user_id INT NOT NULL,
     admin_id INT NOT NULL,

--- a/schemas/chapters_schema.sql
+++ b/schemas/chapters_schema.sql
@@ -1,7 +1,6 @@
 USE homes_for_heroes;
 
-DROP TABLE IF EXISTS chapters;
-CREATE TABLE chapters (
+CREATE TABLE IF NOT EXISTS chapters (
     chapter_name VARCHAR(255) NOT NULL,
     chapter_id INT NOT NULL AUTO_INCREMENT,
     PRIMARY KEY(chapter_id)

--- a/schemas/custom_form_schemas.sql
+++ b/schemas/custom_form_schemas.sql
@@ -1,9 +1,8 @@
-CREATE SCHEMA IF NOT EXISTS homes_for_heroes;
 
 USE homes_for_heroes;
 
-DROP TABLE IF EXISTS CustomForm;
-CREATE TABLE CustomForm (
+
+CREATE TABLE  IF NOT EXISTS CustomForm (
     form_id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     admin_id INT NOT NULL,
     created_date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/schemas/external_relations_schema.sql
+++ b/schemas/external_relations_schema.sql
@@ -1,9 +1,7 @@
-CREATE SCHEMA IF NOT EXISTS homes_for_heroes;
 
 USE homes_for_heroes;
 
-DROP TABLE IF EXISTS partners;
-CREATE TABLE partners (
+CREATE TABLE  IF NOT EXISTS partners (
     partner_id INT NOT NULL AUTO_INCREMENT,
     org_name CHAR(255) NOT NULL UNIQUE,
     city CHAR(255),
@@ -14,8 +12,7 @@ CREATE TABLE partners (
     PRIMARY KEY (partner_id)
 );
 
-DROP TABLE IF EXISTS volunteers;
-CREATE TABLE volunteers (
+CREATE TABLE IF NOT EXISTS volunteers (
     volunteer_id INT NOT NULL AUTO_INCREMENT,
     name CHAR(255) NOT NULL,
     village CHAR(255),
@@ -26,8 +23,7 @@ CREATE TABLE volunteers (
     PRIMARY KEY (volunteer_id)
 );
 
-DROP TABLE IF EXISTS supporters;
-CREATE TABLE supporters (
+CREATE TABLE IF NOT EXISTS supporters (
     supporter_id INT NOT NULL AUTO_INCREMENT,
     name CHAR(255) NOT NULL,
     date_gifted DATE NOT NULL,

--- a/schemas/mysql.sh
+++ b/schemas/mysql.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+echo "CREATE DATABASE IF NOT EXISTS homes_for_heroes;" >  /mainschema.sql
+echo "USE homes_for_heroes;" >>  /mainschema.sql
+echo "ALTER USER root@localhost IDENTIFIED WITH caching_sha2_password BY '$MYSQL_ROOT_PASSWORD';">>  /mainschema.sql
+echo "CREATE USER IF NOT EXISTS '$MYSQL_USER'@'%' IDENTIFIED WITH caching_sha2_password BY '$MYSQL_PASSWORD';" >> /mainschema.sql
+
+echo "GRANT ALL PRIVILEGES ON homes_for_heroes.* to  '$MYSQL_USER'@'%' ;" >>  /mainschema.sql
+echo "USE homes_for_heroes;" >>  /mainschema.sql
+echo "FLUSH PRIVILEGES;" >>  /mainschema.sql
+
+echo "USE homes_for_heroes;" >>  /mainschema.sql
+
+
+cat admin_client_schema.sql >> /mainschema.sql
+cat user_schema.sql >> /mainschema.sql
+cat chapters_schema.sql >> /mainschema.sql
+cat custom_form_schemas.sql >> /mainschema.sql
+cat external_relations_schema.sql >> /mainschema.sql
+#cat sample_schema.sql >> /mainschema.sql
+
+
+if  [ -d  "/var/lib/mysql"  ]; then 
+    mysqld --initialize
+    mysqld --user=root  --init-file="/mainschema.sql"
+
+else 
+    mysqld  --user=root --init-file="/mainschema.sql"
+
+fi

--- a/schemas/user_schema.sql
+++ b/schemas/user_schema.sql
@@ -1,10 +1,8 @@
-CREATE SCHEMA IF NOT EXISTS homes_for_heroes;
 
 USE homes_for_heroes;
 
 
-DROP TABLE IF EXISTS UserInfo;
-CREATE TABLE UserInfo (
+CREATE TABLE  IF NOT EXISTS UserInfo (
     user_id INT PRIMARY KEY,
     gender CHAR(1) DEFAULT NULL,
     email CHAR(255) DEFAULT NULL,
@@ -21,8 +19,7 @@ CREATE TABLE UserInfo (
     CONSTRAINT FOREIGN KEY (user_id) REFERENCES client_users(user_id) ON DELETE CASCADE
 );
 
-DROP TABLE IF EXISTS NextKin;
-CREATE TABLE NextKin (
+CREATE TABLE IF NOT EXISTS NextKin (
     kin_id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     user_id INT NOT NULL,
     kin_name CHAR(255) NOT NULL,
@@ -33,8 +30,7 @@ CREATE TABLE NextKin (
 	CONSTRAINT FOREIGN KEY (user_id) REFERENCES client_users(user_id)
 );
 
-DROP TABLE IF EXISTS MedicalHistory;
-CREATE TABLE MedicalHistory (
+CREATE TABLE IF NOT EXISTS MedicalHistory (
     user_id INT PRIMARY KEY, 
     vision_impairment BOOLEAN,
     incontinent BOOLEAN,


### PR DESCRIPTION
### Use Bash script to automate schema creation for mysql in docker
conceptually we are appending SQL files to a large files and then utilizing mysqld --init-file= to automate the whole process of schema creation


- Addtionally needed to clean up the scheme structure to meet our spec
- Changed docker-compose and backend dockerfile to accept new connections
- Added a mysql.sh file and provided execute permission
- Changed how MySQL container runs to our mysql.sh script